### PR TITLE
WIP: Try out TLS passthrough for nginx

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -15,6 +15,8 @@ tasks:
     cmds:
       - minikube addons enable ingress
       - minikube addons enable ingress-dns
+      - |
+        minikube kubectl -- patch deployment -n ingress-nginx ingress-nginx-controller --type='json' -p='[{"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value":"--enable-ssl-passthrough"}]'
 
   install-keycloak-operator:
     # https://www.keycloak.org/operator/installation
@@ -68,10 +70,7 @@ tasks:
           NAME: keycloak
       - kubectl -n {{.NAMESPACE}} create secret generic keycloak-db-secret --from-literal=username=testuser --from-literal=password=testpassword || true
       - NAMESPACE={{.NAMESPACE}} MINIKUBE_IP={{.MINIKUBE_IP}} envsubst < resources/keycloak.yaml | kubectl -n {{.NAMESPACE}} apply -f -
-      - sleep 5
       - kubectl -n {{.NAMESPACE}} wait --for=condition=Ready --timeout=180s keycloaks.k8s.keycloak.org/keycloak-kubernetes-quickstart
-      - NAMESPACE={{.NAMESPACE}} MINIKUBE_IP={{.MINIKUBE_IP}} envsubst < resources/keycloak-ingress-tls-patch.yaml > .task/ingress-patch.yaml
-      - kubectl -n {{.NAMESPACE}} patch ingress keycloak-kubernetes-quickstart-ingress --patch-file .task/ingress-patch.yaml
       - NAMESPACE={{.NAMESPACE}} MINIKUBE_IP={{.MINIKUBE_IP}} envsubst < resources/keycloak-realm-import.yaml | kubectl -n {{.NAMESPACE}} apply -f -
       - |
         echo "Access Keycloak on https://keycloak.{{.NAMESPACE}}.{{.MINIKUBE_IP}}.nip.io"

--- a/rebuild-minikube.sh
+++ b/rebuild-minikube.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+if [[ "$RUNNER_DEBUG" == "1" ]]; then
+  set -x
+fi
+set -e
+
+if [ "$GITHUB_ACTIONS" == "" ]; then
+  #prerequisite checks
+  #this test is valid only on Linux, and would fail on Windows, MacOS
+  if [ "$(uname)" == "Linux" ]; then
+   if [ "$(egrep -c 'vmx|svm' /proc/cpuinfo)" -gt 0 ]; then
+     echo "PRE-REQ CHECK PASSED: Virtualization is enabled on the host machine, its safe to proceed."
+   else
+     echo >&2 "PRE-REQ CHECK FAILED: Virtualization is not enabled properly on the host machine. Please check the installation docs."
+     exit 1
+   fi
+  fi
+
+  # this test is valid only on Linux, and would fail on Windows
+  if [ "$(uname)" == "Linux" ]; then
+    if [ "$(getent group libvirt | grep -c $USER)" -gt 0 ]; then
+      echo "PRE-REQ CHECK PASSED: User is found in the libvirt group."
+    else
+      echo >&2 "PRE-REQ CHECK FAILED: User is not found in the libvirt group. Please check the installation docs."
+      exit 1
+    fi
+  fi
+
+  minikube delete
+  minikube config set memory 8192
+  minikube config set cpus 4
+  DRIVER=kvm2
+  if [ "$(uname)" == "Darwin" ]; then
+    DRIVER=hyperkit
+  elif [ "$(expr substr "$(uname -s)" 1 10)" == "MINGW64_NT" ]; then
+    DRIVER=hyperv
+  fi
+  minikube config set driver ${DRIVER}
+  minikube config set container-runtime docker
+  # the version of Kubernetes needs to be in-sync with `provision-minikube.yml`
+  minikube start --disk-size=64GB --container-runtime=docker --driver=${DRIVER} --docker-opt="default-ulimit=nofile=102400:102400" --kubernetes-version=v1.30.0
+fi
+rm -rf .task
+echo "Minikube initialized. Now run 'task' to provision it with Keycloak"

--- a/resources/keycloak.yaml
+++ b/resources/keycloak.yaml
@@ -23,3 +23,4 @@ spec:
   ingress:
     annotations:
       nginx.ingress.kubernetes.io/proxy-buffer-size: "8k"
+      nginx.ingress.kubernetes.io/ssl-passthrough: "true"


### PR DESCRIPTION
I'm trying out TLS Passthrough for nginx, and I found that it would work when Keycloak would use the port name and not the port number when specifying the ingress. 

I've raised a bug with the nginx-ingress controller here, see https://github.com/kubernetes/ingress-nginx/issues/11517